### PR TITLE
fix: updated the crunchy subscriptions according to the official source

### DIFF
--- a/src/app/services/plats-subs.service.ts
+++ b/src/app/services/plats-subs.service.ts
@@ -17,7 +17,7 @@ export class PlatsSubsService {
       subscriptions: [
       {
           name: 'Ultimate Fan',
-          membershipMonthsDuration: [1, 12],
+          membershipMonthsDuration: [1],
         },
         {
           name: 'Mega Fan',


### PR DESCRIPTION
The Ultimate fan subscription is only available for one month, according to the following link:
https://store.crunchyroll.com/products/premium-streaming-membership-digital-gift-fan-tier-Ultimate_Fan_1_Month.html