### PR TITLE
Carousel fix

### DIFF
--- a/src/app/components/landing/plats-carousel/plats-carousel.component.css
+++ b/src/app/components/landing/plats-carousel/plats-carousel.component.css
@@ -18,7 +18,7 @@
     --cards-number: 2;
   }
 
-  @media (max-width: 450px) {
+  @media (max-width: 600px) {
     --cards-number: 1;
   }
 }

--- a/src/app/components/landing/plats-carousel/plats-carousel.component.ts
+++ b/src/app/components/landing/plats-carousel/plats-carousel.component.ts
@@ -1,4 +1,4 @@
-import { Component, input, signal } from '@angular/core';
+import { Component, ElementRef, inject, input, signal } from '@angular/core';
 
 @Component({
   selector: 'plats-carousel',
@@ -7,7 +7,8 @@ import { Component, input, signal } from '@angular/core';
   styleUrl: './plats-carousel.component.css',
 })
 export class PlatsCarouselComponent {
-  public mode = input<'complex'|'simple'>('complex');
+  public mode = input<'complex' | 'simple'>('complex');
+  private element = inject(ElementRef).nativeElement as HTMLElement;
   cards = signal([
     {
       subscription: '1',
@@ -71,21 +72,19 @@ export class PlatsCarouselComponent {
     },
   ]);
 
-  // FIXME: Refactor this method
   scrollLeft() {
-    const card = document.querySelector('.card-container');
+    const content = this.element.querySelector('.content');
+    const card = this.element.querySelector('.card-container');
     const cardDimension = card?.getBoundingClientRect();
     const containerWidth = cardDimension?.width;
-    const content = document.querySelector('.content');
     content!.scrollLeft -= containerWidth! + 20;
   }
 
-  // FIXME: Refactor this method
   scrollRight() {
-    const card = document.querySelector('.card-container');
+    const content = this.element.querySelector('.content');
+    const card = this.element.querySelector('.card-container');
     const cardDimension = card?.getBoundingClientRect();
     const containerWidth = cardDimension?.width;
-    const content = document.querySelector('.content');
     content!.scrollLeft += containerWidth! + 20;
   }
 }


### PR DESCRIPTION
This includes a fix in:

- When more than 1 carrousel in the document, the arrows now work separately (used the selector from the component itself, not the document)
- Responsive design improved in smaller devices -> Now only showing 1 card for devices for up to 600px